### PR TITLE
HistoryGrip Update

### DIFF
--- a/CountDown/CoreData/CountDown.xcdatamodeld/CountDown.xcdatamodel/contents
+++ b/CountDown/CoreData/CountDown.xcdatamodeld/CountDown.xcdatamodel/contents
@@ -30,8 +30,12 @@
     <entity name="HistoryGrip" representedClassName="HistoryGrip" syncable="YES">
         <attribute name="breakMinutes" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="breakSeconds" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="customRestSeconds" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformerName" customClassName="[Int]"/>
+        <attribute name="customWorkSeconds" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformerName" customClassName="[Int]"/>
+        <attribute name="decrementSets" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="edgeSize" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="gripTypeName" attributeType="String"/>
+        <attribute name="hasCustomDurations" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="lastBreakMinutes" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="lastBreakSeconds" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="repCount" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>

--- a/CountDown/CoreData/HistoryGrip+CoreDataProperties.swift
+++ b/CountDown/CoreData/HistoryGrip+CoreDataProperties.swift
@@ -25,9 +25,13 @@ extension HistoryGrip {
     @NSManaged public var breakSeconds: Int16
     @NSManaged public var lastBreakMinutes: Int16
     @NSManaged public var lastBreakSeconds: Int16
+    @NSManaged public var decrementSets: Bool
+    @NSManaged public var hasCustomDurations: Bool
     @NSManaged public var edgeSize: Int16
     @NSManaged public var sequenceNum: Int16
     @NSManaged public var workoutHistory: WorkoutHistory?
+    @NSManaged public var customWorkSeconds: [Int]?
+    @NSManaged public var customRestSeconds: [Int]?
     
     public var unwrappedBreakMinutes: Int {
         Int(breakMinutes)
@@ -71,6 +75,22 @@ extension HistoryGrip {
     
     public var unwrappedGripTypeName: String {
         gripTypeName ?? "Unknown Grip Type"
+    }
+    
+    public var unwrappedDecrementSets: Bool {
+        decrementSets
+    }
+    
+    public var unwrappedHasCustomDurations: Bool {
+        hasCustomDurations
+    }
+    
+    public var unwrappedCustomWork: [Int] {
+        customWorkSeconds ?? [Int](repeating: 7, count: maxNumberOfReps)
+    }
+    
+    public var unwrappedCustomRest: [Int] {
+        customRestSeconds ?? [Int](repeating: 3, count: maxNumberOfReps)
     }
 
 }

--- a/CountDown/ViewModels/WorkoutHistoryViewModel.swift
+++ b/CountDown/ViewModels/WorkoutHistoryViewModel.swift
@@ -56,6 +56,10 @@ struct WorkoutHistoryViewModel {
                 historyGrip.breakSeconds = grip.breakSeconds
                 historyGrip.lastBreakMinutes = grip.lastBreakMinutes
                 historyGrip.lastBreakSeconds = grip.lastBreakSeconds
+                historyGrip.decrementSets = grip.decrementSets
+                historyGrip.hasCustomDurations = grip.hasCustomDurations
+                historyGrip.customWorkSeconds = grip.customWorkSeconds
+                historyGrip.customRestSeconds = grip.customRestSeconds
                 historyGrip.edgeSize = grip.edgeSize
                 historyGrip.sequenceNum = grip.sequenceNum
             }

--- a/CountDown/Views/History/HistoryGripCardView.swift
+++ b/CountDown/Views/History/HistoryGripCardView.swift
@@ -26,8 +26,8 @@ struct HistoryGripCardView: View {
                     }
                     Spacer()
                     VStack(alignment: .leading) {
-                        Text("Work: \(historyGrip.unwrappedWorkSeconds)s")
-                        Text("Rest: \(historyGrip.unwrappedRestSeconds)s")
+                        Text("Work: \(workSecondsString)")
+                        Text("Rest: \(restSecondsString)")
                     }
                     Spacer()
                     VStack(alignment: .leading) {
@@ -40,6 +40,26 @@ struct HistoryGripCardView: View {
                 .foregroundColor(Color(.systemGray))
             }
         }
+    }
+    
+    /// Shows the work seconds or a message if history grip has custom durations
+    private var workSecondsString: String {
+        if historyGrip.hasCustomDurations {
+            return customDurationsString(
+                customSeconds: historyGrip.unwrappedCustomWork,
+                range: historyGrip.unwrappedRepCount)
+        }
+        return "\(historyGrip.unwrappedWorkSeconds)s"
+    }
+    
+    /// Shows the rest seconds or a message if history grip has custom durations
+    private var restSecondsString: String {
+        if historyGrip.hasCustomDurations {
+            return customDurationsString(
+                customSeconds: historyGrip.unwrappedCustomRest,
+                range: historyGrip.unwrappedRepCount - 1)
+        }
+        return "\(historyGrip.unwrappedRestSeconds)s"
     }
 }
 

--- a/CountDownTests/CoreData/HistoryGripPropertiesTest.swift
+++ b/CountDownTests/CoreData/HistoryGripPropertiesTest.swift
@@ -50,6 +50,9 @@ final class HistoryGripPropertiesTest: XCTestCase {
         historyGrip.breakSeconds = 30
         historyGrip.lastBreakMinutes = 1
         historyGrip.lastBreakSeconds = 30
+        historyGrip.hasCustomDurations = true
+        historyGrip.customWorkSeconds = [3, 6, 9, 12]
+        historyGrip.customRestSeconds = [30, 35, 40, 45]
         historyGrip.edgeSize = 18
         historyGrip.sequenceNum = 2
         
@@ -61,6 +64,9 @@ final class HistoryGripPropertiesTest: XCTestCase {
         XCTAssertEqual(historyGrip.unwrappedBreakSeconds, 30)
         XCTAssertEqual(historyGrip.unwrappedLastBreakMinutes, 1)
         XCTAssertEqual(historyGrip.unwrappedLastBreakSeconds, 30)
+        XCTAssertEqual(historyGrip.unwrappedHasCustomDurations, true)
+        XCTAssertEqual(historyGrip.unwrappedCustomWork, [3, 6, 9, 12])
+        XCTAssertEqual(historyGrip.unwrappedCustomRest, [30, 35, 40, 45])
         XCTAssertEqual(historyGrip.unwrappedEdgeSize, 18)
         XCTAssertEqual(historyGrip.unwrappedSequenceNum, 2)
         XCTAssertEqual(historyGrip.unwrappedGripTypeName, "Full Crimp")
@@ -78,6 +84,11 @@ final class HistoryGripPropertiesTest: XCTestCase {
         XCTAssertEqual(historyGrip.unwrappedBreakSeconds, 0)
         XCTAssertEqual(historyGrip.unwrappedLastBreakMinutes, 0)
         XCTAssertEqual(historyGrip.unwrappedLastBreakSeconds, 0)
+        XCTAssertEqual(historyGrip.unwrappedHasCustomDurations, false)
+        XCTAssertEqual(historyGrip.unwrappedCustomWork.count, maxNumberOfReps)
+        XCTAssertEqual(historyGrip.unwrappedCustomWork.first, 7)
+        XCTAssertEqual(historyGrip.unwrappedCustomRest.count, maxNumberOfReps)
+        XCTAssertEqual(historyGrip.unwrappedCustomRest.first, 3)
         XCTAssertNil(historyGrip.unwrappedEdgeSize)
         XCTAssertEqual(historyGrip.unwrappedSequenceNum, 0)
         XCTAssertEqual(historyGrip.unwrappedGripTypeName, "Unknown Grip Type")

--- a/CountDownTests/ViewModels/WorkoutHistoryViewModelTests.swift
+++ b/CountDownTests/ViewModels/WorkoutHistoryViewModelTests.swift
@@ -53,6 +53,9 @@ final class WorkoutHistoryViewModelTests: XCTestCase {
         grip2.breakSeconds = 45
         grip2.lastBreakMinutes = 1
         grip2.lastBreakSeconds = 45
+        grip2.hasCustomDurations = true
+        grip2.customWorkSeconds = [7, 7, 7, 7, 7]
+        grip2.customRestSeconds = [3, 3, 3, 3, 3]
         grip2.edgeSize = 16
         grip2.sequenceNum = 2
         grip2.gripType = gripType2
@@ -86,6 +89,7 @@ final class WorkoutHistoryViewModelTests: XCTestCase {
         XCTAssertEqual(savedHistory?.gripArray[0].breakSeconds, 30)
         XCTAssertEqual(savedHistory?.gripArray[0].lastBreakMinutes, 1)
         XCTAssertEqual(savedHistory?.gripArray[0].lastBreakSeconds, 30)
+        XCTAssertFalse(savedHistory!.gripArray[0].hasCustomDurations)
         XCTAssertEqual(savedHistory?.gripArray[0].edgeSize, 18)
         XCTAssertEqual(savedHistory?.gripArray[0].sequenceNum, 1)
         XCTAssertEqual(savedHistory?.gripArray[0].gripTypeName, "Full Crimp")
@@ -98,6 +102,9 @@ final class WorkoutHistoryViewModelTests: XCTestCase {
         XCTAssertEqual(savedHistory?.gripArray[1].breakSeconds, 45)
         XCTAssertEqual(savedHistory?.gripArray[1].lastBreakMinutes, 1)
         XCTAssertEqual(savedHistory?.gripArray[1].lastBreakSeconds, 45)
+        XCTAssertTrue(savedHistory!.gripArray[1].hasCustomDurations)
+        XCTAssertEqual(savedHistory?.gripArray[1].customWorkSeconds, [7, 7, 7, 7, 7])
+        XCTAssertEqual(savedHistory?.gripArray[1].customRestSeconds, [3, 3, 3, 3, 3])
         XCTAssertEqual(savedHistory?.gripArray[1].edgeSize, 16)
         XCTAssertEqual(savedHistory?.gripArray[1].sequenceNum, 2)
         XCTAssertEqual(savedHistory?.gripArray[1].gripTypeName, "Half Crimp")


### PR DESCRIPTION
Modified HistoryGrip to account for custom reps. Allows users to see if grip history had custom durations.