### PR TITLE
Audio Mixing Fix

### DIFF
--- a/.github/workflows/ios_fastlane.yml
+++ b/.github/workflows/ios_fastlane.yml
@@ -30,9 +30,8 @@ jobs:
       - uses: actions/checkout@v2
  
       - name: Set up ruby env
-        uses: ruby/setup-ruby@v1.138.0
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2.1
           bundler-cache: true
  
       - name: Decode signing certificate into a file

--- a/.github/workflows/ios_fastlane.yml
+++ b/.github/workflows/ios_fastlane.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Set up ruby env
         uses: ruby/setup-ruby@v1
         with:
+          ruby-version: 3.3
           bundler-cache: true
  
       - name: Decode signing certificate into a file

--- a/CountDown.xcodeproj/project.pbxproj
+++ b/CountDown.xcodeproj/project.pbxproj
@@ -1013,7 +1013,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.project.CountDown;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1049,7 +1049,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.project.CountDown;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/CountDown/CountDownApp.swift
+++ b/CountDown/CountDownApp.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import AVFAudio
 
 @main
 struct CountDownApp: App {
@@ -22,6 +23,9 @@ struct CountDownApp: App {
         } else {
             persistenceController = PersistenceController.shared
         }
+        
+        // Allow music or sounds from other apps to play and "mix" with timer sounds
+        try? AVAudioSession.sharedInstance().setCategory(AVAudioSession.Category.ambient, options: [])
     }
     
     var body: some Scene {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -21,7 +21,7 @@ platform :ios do
   desc "Run tests for CountDown"
   lane :tests do
     run_tests(project: "CountDown.xcodeproj",
-              devices: ["iPhone 14 Pro"])
+              devices: ["iPhone 15 Pro"])
   end
 
   desc "Build and upload to TestFlight"


### PR DESCRIPTION
Fixed an issue where audio from other apps, such as the Music app, was not allowed to play while the countdown timer was running. Now, the audio from the timer and other apps mix together so users can hear both.